### PR TITLE
Feature: Independent patching thread.

### DIFF
--- a/dpatch/CMakeLists.txt
+++ b/dpatch/CMakeLists.txt
@@ -7,6 +7,10 @@ project(
     LANGUAGES C
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+find_package(Threads REQUIRED)
+
 add_library(dpatch SHARED
     ${PROJECT_SOURCE_DIR}/main.c
     ${PROJECT_SOURCE_DIR}/x64_code_generator.c
@@ -19,7 +23,7 @@ add_library(dpatch SHARED
 
 set_property(TARGET dpatch PROPERTY C_STANDARD 99)
 
-target_link_libraries(dpatch PUBLIC ${CMAKE_DL_LIBS})
+target_link_libraries(dpatch PRIVATE ${CMAKE_DL_LIBS} Threads::Threads)
 
 target_include_directories(dpatch PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 


### PR DESCRIPTION
This feature moves patch application to an independent, dedicated thread.

The previous implementation performed the patch in the signal handler's interrupt context, which prevented us from using non-reentrant function such as `malloc` - this mean we had to allocate and parse the patch at startup. Defining the patch to be applied at startup is not acceptable for a dynamic patch which may not be known until the program has been running for weeks or more.

We can now parse a patch script at runtime by running the patch in a separate thread,